### PR TITLE
Add inline waitlist signup and update guarantees

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,6 +156,11 @@
             margin-right: auto;
             opacity: 0.95;
         }
+
+        .hero .inline-form-intro {
+            font-size: 1.05rem;
+            margin-bottom: 0.5rem;
+        }
         
         .cta-buttons {
             display: flex;
@@ -164,7 +169,7 @@
             flex-wrap: wrap;
             margin-bottom: 1.5rem;
         }
-        
+
         .btn-primary {
             background: #FF7A00;
             color: white;
@@ -194,10 +199,62 @@
             transition: all 0.2s ease;
             display: inline-block;
         }
-        
+
         .btn-secondary:hover {
             background: white;
             color: #071A2E;
+        }
+
+        .email-form {
+            display: flex;
+            justify-content: center;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            margin-top: 1rem;
+        }
+
+        .email-input {
+            padding: 0.85rem 1rem;
+            border-radius: 8px;
+            border: none;
+            min-width: 260px;
+            font-size: 1rem;
+        }
+
+        .visually-hidden {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
+
+        .email-submit {
+            background: #00B7C2;
+            color: white;
+            border: none;
+            padding: 0.9rem 1.75rem;
+            border-radius: 8px;
+            font-weight: 600;
+            cursor: pointer;
+            font-size: 1rem;
+            transition: background-color 0.2s ease, transform 0.2s ease;
+        }
+
+        .email-submit:hover {
+            background: #0092a4;
+            transform: translateY(-2px);
+        }
+
+        .form-note {
+            font-size: 0.85rem;
+            text-align: center;
+            margin-top: 0.5rem;
+            opacity: 0.8;
         }
         
         .micro-trust {
@@ -425,6 +482,17 @@
                 flex-direction: column;
                 gap: 1rem;
             }
+
+            .email-form {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            .email-input,
+            .email-submit {
+                width: 100%;
+                max-width: 320px;
+            }
         }
         
         @media (max-width: 480px) {
@@ -463,10 +531,17 @@
             <h1>HR without the corporate spin</h1>
             <p>The truths HR won't tell you. Get insider answers that protect your career and help you win reviews, interviews, and tough conversations.</p>
             <div class="cta-buttons">
-                <a href="<REPLACE_WITH_BOOKING_URL>" class="btn-primary" aria-label="Book a 30-minute HR prep call for $149">Book a 30-Minute HR Prep Call ($149)</a>
-                <a href="<REPLACE_WITH_WAITLIST_URL>" class="btn-secondary" aria-label="Join the waitlist">Join the Waitlist</a>
+                <a href="<REPLACE_WITH_WAITLIST_URL>" class="btn-primary" aria-label="Join the waitlist">Join the Waitlist</a>
+                <a href="<REPLACE_WITH_BOOKING_URL>" class="btn-secondary" aria-label="Book a 30-minute HR prep call for $149">Book a 30-Minute HR Prep Call ($149)</a>
             </div>
-            <p class="micro-trust">Paid calls only. Limited weekly slots to protect quality.</p>
+            <p class="inline-form-intro">Join the list to get insider HR tips (and first dibs on call slots).</p>
+            <form class="email-form" action="<REPLACE_WITH_WAITLIST_URL>" method="post">
+                <label for="hero-email" class="visually-hidden">Email address</label>
+                <input type="email" id="hero-email" name="email" class="email-input" placeholder="you@example.com" required>
+                <button type="submit" class="email-submit">Get insider tips</button>
+            </form>
+            <p class="form-note">We never share your email. Unsubscribe anytime.</p>
+            <p class="micro-trust">Paid calls stay limited so every session stays sharp. If there’s a booking issue or you’re not satisfied with the session quality, I’ll make it right.</p>
         </div>
     </section>
 
@@ -524,8 +599,8 @@
             <section class="section">
                 <h2>Ready to get the real HR playbook</h2>
                 <div class="cta-buttons">
-                    <a href="<REPLACE_WITH_BOOKING_URL>" class="btn-primary" aria-label="Book a 30-minute HR prep call for $149">Book a 30-Minute HR Prep Call ($149)</a>
-                    <a href="<REPLACE_WITH_WAITLIST_URL>" class="btn-secondary" aria-label="Join the waitlist">Join the Waitlist</a>
+                    <a href="<REPLACE_WITH_WAITLIST_URL>" class="btn-primary" aria-label="Join the waitlist">Join the Waitlist</a>
+                    <a href="<REPLACE_WITH_BOOKING_URL>" class="btn-secondary" aria-label="Book a 30-minute HR prep call for $149">Book a 30-Minute HR Prep Call ($149)</a>
                 </div>
             </section>
 
@@ -554,7 +629,7 @@
                     <div class="faq-item">
                         <details>
                             <summary>Do you offer refunds</summary>
-                            <p>Calls are non-refundable once delivered. If a booking issue occurs, we will make it right.</p>
+                            <p>Calls are non-refundable once delivered. If there’s a booking issue or you’re not satisfied with the session quality, I’ll make it right.</p>
                         </details>
                     </div>
                     <div class="faq-item">


### PR DESCRIPTION
## Summary
- add an inline waitlist signup form beneath the hero CTA with a privacy reassurance
- reorder primary calls to action to prioritize the low-friction waitlist and emphasize the guarantee copy
- style the new form and refresh FAQ language to reflect the updated satisfaction promise

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dce7a57bdc8328ad081fa3a2fa691b